### PR TITLE
Add rule saving and auto-detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,9 @@ python run.py
 Then navigate to `http://localhost:5000/` and upload a pentest report PDF. Uploaded files are stored in the `uploads/` directory.
 
 After uploading, you will be redirected to `/review` where the extracted findings are displayed in an editable table. You can add or remove rows and columns, rename the headers, and toggle a debug view that shows the raw text next to the parsed data. A "Save Parsing Rule" button lets you store custom column configurations to the `rules/` directory.
+
+## Saving Parsing Rules
+
+When reviewing a report you can click **Save Parsing Rule** to persist your preferred column setup along with a signature of the uploaded file. Rules are stored as JSON files in the `rules/` folder and include the MD5 hash of the report or a regex that matches text on the first page. On future uploads the application automatically checks these rules using the file hash or first page content and applies the matching column configuration.
+
+You can also save rules programmatically by sending a `POST` request to the `/save_rule` endpoint with a JSON body containing a `name` and a `rule` object.

--- a/app/templates/review.html
+++ b/app/templates/review.html
@@ -25,22 +25,18 @@
   <table id="findingsTable">
     <thead>
       <tr>
-        <th contenteditable="true">title</th>
-        <th contenteditable="true">severity</th>
-        <th contenteditable="true">description</th>
-        <th contenteditable="true">remediation</th>
-        <th contenteditable="true">assets</th>
+        {% for col in columns %}
+          <th contenteditable="true">{{ col }}</th>
+        {% endfor %}
         <th>Actions</th>
       </tr>
     </thead>
     <tbody>
     {% for f in findings %}
       <tr>
-        <td contenteditable="true">{{ f.title }}</td>
-        <td contenteditable="true">{{ f.severity }}</td>
-        <td contenteditable="true">{{ f.description }}</td>
-        <td contenteditable="true">{{ f.remediation }}</td>
-        <td contenteditable="true">{{ f.assets }}</td>
+        {% for col in columns %}
+          <td contenteditable="true">{{ f.get(col, '') }}</td>
+        {% endfor %}
         <td><button class="removeRow">Delete</button></td>
       </tr>
     {% endfor %}
@@ -49,6 +45,7 @@
   <button id="addRowBtn">Add Finding</button>
 <script>
 $(function(){
+  var fileHash = "{{ file_hash }}";
   $('#debugBtn').on('click', function(){
     $('#raw-container').toggle();
   });
@@ -96,7 +93,7 @@ $(function(){
       var t=$(this).text();
       if(t!=='Actions') cols.push(t);
     });
-    $.ajax({url:'/save_rule',method:'POST',contentType:'application/json',data:JSON.stringify({name:name,rule:{columns:cols}})})
+    $.ajax({url:'/save_rule',method:'POST',contentType:'application/json',data:JSON.stringify({name:name,rule:{columns:cols,file_hash:fileHash}})})
     .done(function(){alert('Rule saved');})
     .fail(function(){alert('Failed to save rule');});
   });


### PR DESCRIPTION
## Summary
- track column rules in new JSON format with file hashes
- load rules when uploading to auto-fill column headers
- expose file hash in review template and save it when persisting rules
- document using `/save_rule` and automatic rule detection

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `pytest -q` (fails: no tests discovered)


------
https://chatgpt.com/codex/tasks/task_e_68510c238f7c832095787dce83788e53